### PR TITLE
Condense requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,12 @@ dependencies = [
     "langchain-core>=0.3.8",
     "python-dotenv>=1.0.1",
     "langgraph-sdk>=0.1.32",
+    "pytest",
+    "langgraph-cli[inmem]>=0.2.7",
 ]
 
 [project.optional-dependencies]
-dev = ["mypy>=1.11.1", "ruff>=0.6.1", "pytest-asyncio"]
+dev = ["mypy>=1.11.1", "ruff>=0.6.1", "pytest-asyncio", "pytest>=8.3.5"]
 
 [build-system]
 requires = ["setuptools>=73.0.0", "wheel"]


### PR DESCRIPTION
In my dev env, I needed to use `python3 -m pip install ...` for both `pytest` and `langgraph-cli[inmem]`, so I just condensed it into `pyproject.toml`.

If this works, we can probably remove the related special instructions from `README.md` as well.