### PR TITLE
feat: static memories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,6 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 .DS_Store
 uv.lock

--- a/.langgraph/static_memories/project_info.json
+++ b/.langgraph/static_memories/project_info.json
@@ -1,0 +1,14 @@
+[
+  {
+    "content": "This is a Python project that uses uv for dependency management and a Makefile for common tasks. It implements a ReAct-style agent with memory persistence capabilities using LangGraph.",
+    "context": "Basic project architecture information"
+  },
+  {
+    "content": "The project uses GitHub Actions for CI/CD with separate workflows for unit tests and integration tests.",
+    "context": "CI/CD information"
+  },
+  {
+    "content": "Common commands include 'make run' to start the agent, 'make lint' for linting, 'make fmt' for formatting, and 'make clean' to clean up resources.",
+    "context": "Common usage commands"
+  }
+] 

--- a/src/agent_template/graph.py
+++ b/src/agent_template/graph.py
@@ -13,54 +13,12 @@ from langgraph.store.base import BaseStore
 
 from agent_template import configuration, tools, utils
 from agent_template.state import State
+from agent_template.memory import ensure_static_memories 
 
 logger = logging.getLogger(__name__)
 
 # Initialize the language model to be used for memory extraction
 llm = init_chat_model()
-
-
-# Helper function to load static memories
-async def ensure_static_memories(store: BaseStore):
-    """Ensure static memories are loaded in the store."""
-    # Check if any static memories exist
-    try:
-        # Try passing only namespace positionally, rest as keywords
-        static_memories = await store.asearch(
-            ("static_memories", "global"),
-            query="",
-            limit=1
-        )
-        if static_memories:
-            logger.info("Static memories already exist in store")
-            return
-    except Exception as e:
-        logger.error(f"Error checking for static memories: {e}")
-        return
-        
-    # Load memories from file
-    logger.info("Loading static memories into store")
-    static_memories_path = Path(".langgraph/static_memories/project_info.json")
-    
-    if not static_memories_path.exists():
-        logger.warning(f"Static memories file not found at {static_memories_path}")
-        return
-        
-    try:
-        with open(static_memories_path, "r") as f:
-            memories = json.load(f)
-            
-        # Add each memory to the store
-        for i, memory in enumerate(memories):
-            # Use positional arguments for aput as that seems to work
-            await store.aput(
-                ("static_memories", "global"),
-                f"static_{i}",
-                memory
-            )
-        logger.info(f"Loaded {len(memories)} static memories into store")
-    except Exception as e:
-        logger.error(f"Error loading static memories: {e}")
 
 
 async def call_model(state: State, config: RunnableConfig, *, store: BaseStore) -> dict:

--- a/src/agent_template/memory.py
+++ b/src/agent_template/memory.py
@@ -1,0 +1,68 @@
+import json
+import logging
+from pathlib import Path
+
+from langgraph.store.base import BaseStore
+
+logger = logging.getLogger(__name__)
+
+# Define the directory where static memory files are stored
+STATIC_MEMORIES_DIR = Path(".langgraph/static_memories/")
+
+
+async def _load_memories_from_directory(directory_path: Path, store: BaseStore):
+    """Load memories from all JSON files in the specified directory into the store."""
+    if not directory_path.is_dir():
+        logger.warning(f"Static memories directory not found at {directory_path}")
+        return
+
+    total_memories_loaded = 0
+    for json_file_path in directory_path.glob("*.json"):
+        try:
+            with open(json_file_path, "r") as f:
+                memories = json.load(f)
+
+            if not isinstance(memories, list):
+                logger.warning(
+                    f"Skipping {json_file_path}: content is not a list of memories."
+                )
+                continue
+
+            # Add each memory from the current file to the store
+            for i, memory in enumerate(memories):
+                # Use a unique key combining filename and index
+                file_name = json_file_path.stem
+                memory_key = f"{file_name}_{i}"
+                # Use positional arguments for aput
+                await store.aput(("static_memories", "global"), memory_key, memory)
+            logger.info(f"Loaded {len(memories)} memories from {json_file_path.name}")
+            total_memories_loaded += len(memories)
+        except json.JSONDecodeError:
+            logger.error(f"Error decoding JSON from {json_file_path}")
+        except Exception as e:
+            logger.error(f"Error loading static memories from {json_file_path}: {e}")
+
+    if total_memories_loaded > 0:
+        logger.info(
+            f"Finished loading static memories. Total loaded: {total_memories_loaded}"
+        )
+    else:
+        logger.info("No static memories found or loaded from the directory.")
+
+
+async def ensure_static_memories(store: BaseStore):
+    """Ensure static memories are loaded in the store by checking existence and loading if necessary."""
+    # Check if any static memories exist
+    try:
+        # Try passing only namespace positionally, rest as keywords
+        static_memories = await store.asearch(("static_memories", "global"), query="", limit=1)
+        if static_memories:
+            logger.debug("Static memories already exist in store, skipping load.")
+            return
+    except Exception as e:
+        # Log the error but proceed, as the store might be empty or have issues
+        logger.warning(f"Could not check for existing static memories, proceeding to load: {e}")
+
+    # Define the directory and load memories
+    logger.info("Attempting to load static memories into store.")
+    await _load_memories_from_directory(STATIC_MEMORIES_DIR, store) 


### PR DESCRIPTION
Initial code for adding static memories to agents.
Memories are read from `.langgraph/static_memories` and loaded (once) when executing `call_model`