### PR TITLE
Basic test for Task Manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ test-architect:
 test_watch:
 	uv run --env-file .env -- python -m ptw --snapshot-update --now . -- -vv tests/unit_tests
 
+test-task-manager:
+	uv run -- pytest -rs $(INTEGRATION_TEST_FILE)test_task_manager.py
+
 test_unit:
 	uv run pytest tests/unit_tests
 test_integration:
@@ -46,6 +49,8 @@ extended_tests:
 set-requirement-dataset:
 	uv run --env-file .env -- python tests/datasets/requirement_gatherer_dataset.py
 
+set-task-manager-dataset:
+	uv run --env-file .env -- python tests/datasets/task_manager_dataset.py
 
 ######################
 # LINTING AND FORMATTING

--- a/src/task_manager/configuration.py
+++ b/src/task_manager/configuration.py
@@ -9,7 +9,8 @@ from typing_extensions import Annotated
 
 from task_manager import prompts
 
-TASK_MANAGER_MODEL="google_genai:gemini-2.5-flash-preview-04-17"
+TASK_MANAGER_MODEL = "google_genai:gemini-2.5-flash-preview-04-17"
+
 
 @dataclass(kw_only=True)
 class Configuration:

--- a/src/task_manager/configuration.py
+++ b/src/task_manager/configuration.py
@@ -9,6 +9,7 @@ from typing_extensions import Annotated
 
 from task_manager import prompts
 
+TASK_MANAGER_MODEL="google_genai:gemini-2.5-flash-preview-04-17"
 
 @dataclass(kw_only=True)
 class Configuration:
@@ -17,7 +18,7 @@ class Configuration:
     user_id: str = "default"
     """The ID of the user to remember in the conversation."""
     model: Annotated[str, {"__template_metadata__": {"kind": "llm"}}] = field(
-        default="google_genai:gemini-2.5-flash-preview-04-17",
+        default=TASK_MANAGER_MODEL,
         metadata={
             "description": "The name of the language model to use for the agent. "
             "Should be in the form: provider/model-name."

--- a/src/task_manager/graph.py
+++ b/src/task_manager/graph.py
@@ -79,4 +79,4 @@ graph = builder.compile()
 graph.name = "Task Manager"
 
 
-__all__ = ["graph"]
+__all__ = ["graph", "builder"]

--- a/src/task_manager/graph.py
+++ b/src/task_manager/graph.py
@@ -11,11 +11,11 @@ from langgraph.prebuilt import ToolNode, tools_condition
 from task_manager import configuration, tools, utils
 from task_manager.state import State
 
-
 logger = logging.getLogger(__name__)
 
 # Initialize the language model
 llm = init_chat_model(model=configuration.TASK_MANAGER_MODEL)
+
 
 async def call_model(state: State, config: RunnableConfig) -> dict:
     """Process user input and generate tasks."""

--- a/src/task_manager/graph.py
+++ b/src/task_manager/graph.py
@@ -11,11 +11,11 @@ from langgraph.prebuilt import ToolNode, tools_condition
 from task_manager import configuration, tools, utils
 from task_manager.state import State
 
+
 logger = logging.getLogger(__name__)
 
 # Initialize the language model
-llm = init_chat_model()
-
+llm = init_chat_model(model=configuration.TASK_MANAGER_MODEL)
 
 async def call_model(state: State, config: RunnableConfig) -> dict:
     """Process user input and generate tasks."""

--- a/tests/datasets/task_manager_dataset.py
+++ b/tests/datasets/task_manager_dataset.py
@@ -1,0 +1,38 @@
+from langsmith import Client
+
+TASK_MANAGER_DATASET_NAME = "task-manager-requirements"
+
+
+def create_dataset():
+    client = Client()
+
+    dataset = client.create_dataset(
+        dataset_name=TASK_MANAGER_DATASET_NAME,
+        description="A sample dataset in LangSmith.",
+    )
+
+    examples = [
+        {
+            "inputs": {
+                "messages": [
+                    {
+                        "role": "human",
+                        "content": "What requirements do you need to make your work done?",
+                    }
+                ]
+            },
+            "outputs": {
+                "message": {"content": "In order to create a task planning, I need to have access to prd.md, techstack.md and split_criteria.md files."}
+            },
+        },
+    ]
+
+    # Add examples to the dataset
+    client.create_examples(dataset_id=dataset.id, examples=examples)
+
+    return dataset
+
+
+# Only create the dataset when this script is run directly
+if __name__ == "__main__":
+    create_dataset()

--- a/tests/datasets/task_manager_dataset.py
+++ b/tests/datasets/task_manager_dataset.py
@@ -22,7 +22,9 @@ def create_dataset():
                 ]
             },
             "outputs": {
-                "message": {"content": "In order to create a task planning, I need to have access to prd.md, techstack.md and split_criteria.md files."}
+                "message": {
+                    "content": "In order to create a task planning, I need to have access to prd.md, techstack.md and split_criteria.md files."
+                }
             },
         },
     ]

--- a/tests/integration_tests/test_task_manager.py
+++ b/tests/integration_tests/test_task_manager.py
@@ -1,0 +1,63 @@
+import pytest
+from langgraph.checkpoint.memory import MemorySaver
+from langsmith import Client
+from testing import create_async_graph_caller, get_logger
+from testing.evaluators import LLMJudge
+from testing.formatter import Verbosity, print_evaluation
+
+from task_manager.graph import builder as graph_builder
+
+# Setup basic logging for the test
+logger = get_logger(__name__)
+
+# Define the LangSmith dataset ID
+LANGSMITH_DATASET_NAME = "task-manager-requirements"
+
+# Create a LLMJudge
+llm_judge = LLMJudge()
+
+@pytest.mark.asyncio
+async def test_task_manager_langsmith(pytestconfig):
+    """
+    Tests the task-manager agent graph using langsmith.aevaluate against a LangSmith dataset.
+    """
+    client = Client()
+
+    if not client.has_dataset(dataset_name=LANGSMITH_DATASET_NAME):
+        logger.error(f"dataset {LANGSMITH_DATASET_NAME} not found")
+        datasets = list(client.list_datasets())
+        logger.error(f"found {len(datasets)} existing datasets")
+        for dataset in datasets:
+            logger.error(f"\tid: {dataset.id}, name: {dataset.name}")
+        pytest.fail(f"dataset {LANGSMITH_DATASET_NAME} not found")
+
+    logger.info(f"evaluating dataset: {LANGSMITH_DATASET_NAME}")
+
+    # Compile the graph - needs checkpointer for stateful execution during evaluation
+    graph_compiled = graph_builder.compile(checkpointer=MemorySaver())
+
+    # Generate a unique thread_id for each evaluation run
+
+    results = await client.aevaluate(
+        create_async_graph_caller(graph_compiled),
+        data=LANGSMITH_DATASET_NAME,  # The whole dataset is used
+        # data=client.list_examples(  # Only the dev split is used
+        #     dataset_name=LANGSMITH_DATASET_NAME, splits=["dev"]
+        # ),
+        # input_mapper=lambda x: x, # Default is identity, maps dataset example to target input
+        # evaluators=[correctness_evaluator],
+        evaluators=[
+            llm_judge.create_correctness_evaluator(
+                plaintext=True
+            )
+        ],
+        experiment_prefix="task-manager-gemini-2.5-correctness-eval-plain",
+        num_repetitions=4,
+        max_concurrency=4,
+        # metadata={"revision_id": "my-test-run-001"} # Optional: Add metadata
+    )
+
+    await print_evaluation(results, client, verbosity=Verbosity.SCORE_DETAILED)
+
+    # Assert that results were produced.
+    assert results is not None, "evaluation did not return results"

--- a/tests/integration_tests/test_task_manager.py
+++ b/tests/integration_tests/test_task_manager.py
@@ -1,26 +1,26 @@
-import pytest
-from langgraph.checkpoint.memory import MemorySaver
-from langsmith import Client
-from typing import Awaitable, Callable
 import uuid
+from typing import Awaitable, Callable
 
+import pytest
+from datasets.task_manager_dataset import (
+    TASK_MANAGER_DATASET_NAME as LANGSMITH_DATASET_NAME,
+)
 from langchain_core.messages import HumanMessage
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph.state import CompiledStateGraph
-
+from langsmith import Client
 from testing import get_logger
 from testing.evaluators import LLMJudge
 from testing.formatter import Verbosity, print_evaluation
 
-from task_manager.configuration import TASK_MANAGER_MODEL
 from task_manager.graph import builder as graph_builder
-
-from datasets.task_manager_dataset import TASK_MANAGER_DATASET_NAME as LANGSMITH_DATASET_NAME
 
 # Setup basic logging for the test
 logger = get_logger(__name__)
 
 # Create a LLMJudge
 llm_judge = LLMJudge()
+
 
 def create_task_manager_graph_caller(
     graph: CompiledStateGraph,
@@ -34,7 +34,7 @@ def create_task_manager_graph_caller(
     async def call_model(inputs: dict):
         # Handle different input formats
         messages = []
-        
+
         # Case 1: Direct message content
         if "message" in inputs and isinstance(inputs["message"], str):
             content = inputs["message"]
@@ -42,29 +42,38 @@ def create_task_manager_graph_caller(
                 messages.append(HumanMessage(content=content))
             else:
                 messages.append(HumanMessage(content="Task manager test query"))
-                
+
         # Case 2: Message object with content
-        elif "message" in inputs and isinstance(inputs["message"], dict) and "content" in inputs["message"]:
+        elif (
+            "message" in inputs
+            and isinstance(inputs["message"], dict)
+            and "content" in inputs["message"]
+        ):
             content = inputs["message"]["content"]
             if content and content.strip():
                 messages.append(HumanMessage(content=content))
             else:
                 messages.append(HumanMessage(content="Task manager test query"))
-        
+
         # Case 3: Messages array (used by LangSmith dataset)
         elif "messages" in inputs and isinstance(inputs["messages"], list):
             for msg in inputs["messages"]:
-                if isinstance(msg, dict) and "role" in msg and msg["role"] == "human" and "content" in msg:
+                if (
+                    isinstance(msg, dict)
+                    and "role" in msg
+                    and msg["role"] == "human"
+                    and "content" in msg
+                ):
                     content = msg["content"]
                     if content and content.strip():
                         messages.append(HumanMessage(content=content))
-        
+
         # Default case if no valid messages were found
         if not messages:
             messages.append(HumanMessage(content="Task manager test query"))
-            
+
         logger.info(f"Processed messages for task manager: {messages}")
-        
+
         state = {"messages": messages}
 
         config = {
@@ -77,7 +86,7 @@ def create_task_manager_graph_caller(
 
         try:
             result = await graph.ainvoke(state, config=config)
-            
+
             if isinstance(result, dict) and "messages" in result and result["messages"]:
                 return result["messages"][-1].content
 
@@ -87,6 +96,7 @@ def create_task_manager_graph_caller(
             return f"Error: {str(e)}"
 
     return call_model
+
 
 @pytest.mark.asyncio
 async def test_task_manager_langsmith(pytestconfig):
@@ -111,18 +121,16 @@ async def test_task_manager_langsmith(pytestconfig):
     # Generate a unique thread_id for each evaluation run
 
     results = await client.aevaluate(
-        create_task_manager_graph_caller(graph_compiled),  # Use specialized caller for task manager
+        create_task_manager_graph_caller(
+            graph_compiled
+        ),  # Use specialized caller for task manager
         data=LANGSMITH_DATASET_NAME,  # The whole dataset is used
         # data=client.list_examples(  # Only the dev split is used
         #     dataset_name=LANGSMITH_DATASET_NAME, splits=["dev"]
         # ),
         # input_mapper=lambda x: x, # Default is identity, maps dataset example to target input
         # evaluators=[correctness_evaluator],
-        evaluators=[
-            llm_judge.create_correctness_evaluator(
-                plaintext=True
-            )
-        ],
+        evaluators=[llm_judge.create_correctness_evaluator(plaintext=True)],
         experiment_prefix="task-manager-gemini-2.5-correctness-eval-plain",
         num_repetitions=4,
         max_concurrency=4,


### PR DESCRIPTION
Add basic evaluation test for Task manager.
Ask which are the requirements for this agent and expect to have prd.md, techstack.md and split_criteria.md in the output.

This will be changed in order to make these inputs compatible with the Architect agent