### PR TITLE
[WIP]POC: coder stub toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,4 @@ GITHUB_REPOSITORY=
 # Agent-specific stub enabling
 # Set to 'true' to use the agent stub
 CODER_STUB_ENABLE=false
+CODE_REVIEWER_STUB_ENABLE=false

--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ GITHUB_APP_ID=
 GITHUB_APP_PRIVATE_KEY=
 # Repository of the project that is being worked on by nexus
 GITHUB_REPOSITORY=
+
+# Agent-specific stub enabling
+# Set to 'true' to use the agent stub
+CODER_STUB_ENABLE=false

--- a/src/code_reviewer/__init__.py
+++ b/src/code_reviewer/__init__.py
@@ -1,5 +1,5 @@
 """Enrichment for a pre-defined schema."""
 
-from agent_template.graph import graph
+from code_reviewer.graph import graph_builder
 
-__all__ = ["graph"]
+__all__ = ["graph_builder"]

--- a/src/coder/graph.py
+++ b/src/coder/graph.py
@@ -1,10 +1,14 @@
 """Graphs that extract memories on a schedule."""
 
+import os
+
 from langchain.chat_models import init_chat_model
-from langchain_core.messages import SystemMessage
+from langchain_core.messages import SystemMessage, ToolMessage
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import Tool
 from langgraph.graph import StateGraph
 from langgraph.prebuilt import ToolNode, tools_condition
+from langgraph.store.base import BaseStore
 
 from coder.prompts import SYSTEM_PROMPT
 from coder.state import State
@@ -25,8 +29,29 @@ class CallModel:
         return {"messages": messages_after_invoke}
 
 
-def graph_builder(github_toolset: list[Tool]) -> StateGraph:
-    """Return coder graph builder."""
+def coder_stub(state: dict, config: RunnableConfig, store: BaseStore):
+    """Stub function for the coder graph."""
+    # Access state as a dictionary, not as an object
+    tool_call_id = state["messages"][-1].tool_calls[0]["id"]
+    return {
+        "messages": [
+            ToolMessage(content="I have finished coding.", tool_call_id=tool_call_id)
+        ]
+    }
+
+
+def build_stub_graph():
+    builder = StateGraph(State)
+    builder.add_node("coder_stub", coder_stub)
+    builder.set_entry_point("coder_stub")
+    builder.set_finish_point("coder_stub")
+    graph = builder.compile()
+    graph.name = "coder"
+    return graph
+
+
+def build_graph(github_toolset: list[Tool]) -> StateGraph:
+    """Return a StateGraph builder for the real coder graph."""
     builder = StateGraph(State)
 
     tool_node = ToolNode(tools=github_toolset)
@@ -37,7 +62,20 @@ def graph_builder(github_toolset: list[Tool]) -> StateGraph:
     builder.add_edge("__start__", "call_model")
     builder.add_conditional_edges("call_model", tools_condition)
     builder.add_edge("tools", "call_model")
-    return builder
+    graph = builder.compile()
+    graph.name = "coder"
+    return graph
+
+
+def graph_builder(tools: list[Tool]):
+    """Build and compile the coder graph, deciding between stub and real implementation."""
+    _coder_stub_enabled = os.getenv("CODER_STUB_ENABLE", "true").lower() != "false"
+
+    if _coder_stub_enabled:
+        return build_stub_graph()
+    else:
+        # If stub is disabled, build the real graph
+        return build_graph(tools)
 
 
 __all__ = ["graph_builder"]

--- a/src/coder/lg_server.py
+++ b/src/coder/lg_server.py
@@ -8,7 +8,9 @@ from coder.tools import get_github_tools
 # TODO: maybe we can setup this to use mock/real github api depending on env/config
 mock_api = MockGithubApi()
 github_tools = get_github_tools(mock_api)
-graph = graph_builder(github_tools).compile()
-graph.name = "Coder"
+graph = graph_builder(github_tools)
+
+# Ensure the graph is named 'coder' to match the reference in the orchestrator
+graph.name = "coder"
 
 __all__ = ["graph"]

--- a/src/orchestrator/graph.py
+++ b/src/orchestrator/graph.py
@@ -10,6 +10,8 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.graph import END, START, StateGraph
 from langgraph.store.base import BaseStore
 
+from code_reviewer.graph import graph as code_reviewer_graph
+
 # Import specific agent graphs
 from coder.lg_server import graph as coder_graph
 from common import utils
@@ -88,7 +90,7 @@ def delegate_to(
             elif tool_call["args"]["to"] == "tester":
                 return stubs.tester.__name__
             elif tool_call["args"]["to"] == "reviewer":
-                return stubs.reviewer.__name__
+                return code_reviewer_graph.name
             # elif tool_call["args"]["to"] == "memorizer":
             #     return stubs.memorizer.__name__
             else:
@@ -105,7 +107,7 @@ builder.add_node(stubs.requirements)
 builder.add_node(stubs.architect)
 builder.add_node(coder_graph)
 builder.add_node(stubs.tester)
-builder.add_node(stubs.reviewer)
+builder.add_node(code_reviewer_graph)
 builder.add_node(stubs.memorizer)
 
 builder.add_edge(START, orchestrate.__name__)
@@ -117,7 +119,7 @@ builder.add_edge(stubs.requirements.__name__, orchestrate.__name__)
 builder.add_edge(stubs.architect.__name__, orchestrate.__name__)
 builder.add_edge("coder", orchestrate.__name__)
 builder.add_edge(stubs.tester.__name__, orchestrate.__name__)
-builder.add_edge(stubs.reviewer.__name__, orchestrate.__name__)
+builder.add_edge(code_reviewer_graph.name, orchestrate.__name__)
 builder.add_edge(stubs.memorizer.__name__, orchestrate.__name__)
 
 graph = builder.compile()

--- a/src/orchestrator/graph.py
+++ b/src/orchestrator/graph.py
@@ -10,6 +10,8 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.graph import END, START, StateGraph
 from langgraph.store.base import BaseStore
 
+# Import specific agent graphs
+from coder.lg_server import graph as coder_graph
 from common import utils
 from orchestrator import configuration, stubs, tools
 from orchestrator.state import State
@@ -82,7 +84,7 @@ def delegate_to(
             elif tool_call["args"]["to"] == "architect":
                 return stubs.architect.__name__
             elif tool_call["args"]["to"] == "coder":
-                return stubs.coder.__name__
+                return coder_graph.name
             elif tool_call["args"]["to"] == "tester":
                 return stubs.tester.__name__
             elif tool_call["args"]["to"] == "reviewer":
@@ -101,7 +103,7 @@ builder.add_node(orchestrate)
 # builder.add_node(store_memory)
 builder.add_node(stubs.requirements)
 builder.add_node(stubs.architect)
-builder.add_node(stubs.coder)
+builder.add_node(coder_graph)
 builder.add_node(stubs.tester)
 builder.add_node(stubs.reviewer)
 builder.add_node(stubs.memorizer)
@@ -113,7 +115,7 @@ builder.add_conditional_edges(
 )
 builder.add_edge(stubs.requirements.__name__, orchestrate.__name__)
 builder.add_edge(stubs.architect.__name__, orchestrate.__name__)
-builder.add_edge(stubs.coder.__name__, orchestrate.__name__)
+builder.add_edge("coder", orchestrate.__name__)
 builder.add_edge(stubs.tester.__name__, orchestrate.__name__)
 builder.add_edge(stubs.reviewer.__name__, orchestrate.__name__)
 builder.add_edge(stubs.memorizer.__name__, orchestrate.__name__)

--- a/src/orchestrator/stubs/__init__.py
+++ b/src/orchestrator/stubs/__init__.py
@@ -42,12 +42,6 @@ model_requirements_messages = MessageWheel(
         """,
     ]
 )
-model_coder_messages = MessageWheel(
-    [
-        """I have finished coding.""",
-        """I fixed the required issue.""",
-    ]
-)
 model_tester_messages = MessageWheel(
     [
         """I found issues with code. Here are the details:
@@ -92,19 +86,6 @@ def architect(state: State, config: RunnableConfig, store: BaseStore):
                 content="""I am finished with the design. Here are the details:
                 The design should be simple HTML file with CSS styling.
                 """,
-                tool_call_id=tool_call_id,
-            )
-        ]
-    }
-
-
-def coder(state: State, config: RunnableConfig, store: BaseStore):
-    """Call code."""
-    tool_call_id = state.messages[-1].tool_calls[0]["id"]
-    return {
-        "messages": [
-            ToolMessage(
-                content=model_coder_messages.next(),
                 tool_call_id=tool_call_id,
             )
         ]

--- a/tests/integration_tests/test_architect_agent.py
+++ b/tests/integration_tests/test_architect_agent.py
@@ -94,8 +94,8 @@ async def test_architect_write_system_requirements(pytestconfig):
     results = await client.aevaluate(
         run_graph_with_attachments,
         data=[client.read_example(example_id="ecadfbbe-bd5b-4108-aba7-8525cec7012e")],
-                evaluators=[
-                llm_judge.create_correctness_evaluator(
+        evaluators=[
+            llm_judge.create_correctness_evaluator(
                 plaintext=True, prompt=ARCHITECT_CORRECTNESS_PROMPT
             )
         ],
@@ -130,8 +130,8 @@ async def test_architect_whole_dataset(pytestconfig):
     results = await client.aevaluate(
         run_graph_with_attachments,
         data=ARCHITECT_DATASET_NAME,
-                evaluators=[
-                llm_judge.create_correctness_evaluator(
+        evaluators=[
+            llm_judge.create_correctness_evaluator(
                 plaintext=True, prompt=ARCHITECT_CORRECTNESS_PROMPT
             )
         ],


### PR DESCRIPTION
This pull request introduces a stub implementation for the coder graph, adds environment-based toggling between the stub and the real implementation, and updates the orchestrator to use the new graph structure. It also removes the old coder stub logic from the orchestrator stubs. Below is a summary of the most important changes:

### Stub Implementation and Graph Updates
* Added a new `coder_stub` function and `build_stub_graph` method in `src/coder/graph.py` to define and compile the stub implementation of the coder graph.
* Updated `graph_builder` in `src/coder/graph.py` to dynamically switch between the stub and the real coder graph based on the `CODER_STUB_ENABLE` environment variable.

### Environment Configuration
* Introduced a new `CODER_STUB_ENABLE` environment variable in `.env.example` to control whether the stub or real coder graph is used.

### Orchestrator Integration
* Replaced the old coder stub in `src/orchestrator/graph.py` with the new `coder_graph` and updated graph edges and delegation logic to use the new graph structure. [[1]](diffhunk://#diff-b3614d9c697e70a544470fe9cff5f7022d38194fa987a06d16c55fdd75f9a26eR13-R14) [[2]](diffhunk://#diff-b3614d9c697e70a544470fe9cff5f7022d38194fa987a06d16c55fdd75f9a26eL85-R87) [[3]](diffhunk://#diff-b3614d9c697e70a544470fe9cff5f7022d38194fa987a06d16c55fdd75f9a26eL104-R106) [[4]](diffhunk://#diff-b3614d9c697e70a544470fe9cff5f7022d38194fa987a06d16c55fdd75f9a26eL116-R118)

### Removal of Legacy Stub Logic
* Removed the old `coder` stub function and associated `model_coder_messages` from `src/orchestrator/stubs/__init__.py`. [[1]](diffhunk://#diff-4c9de601c17b915fb1bdccbc6197dcc3a4d9053f1b1fc2b58a6824cc7f0661c0L45-L50) [[2]](diffhunk://#diff-4c9de601c17b915fb1bdccbc6197dcc3a4d9053f1b1fc2b58a6824cc7f0661c0L101-L113)

These changes improve modularity and allow for easier testing by enabling a switchable stub for the coder graph.