### PR TITLE
add cursor rule to always read project memory

### DIFF
--- a/.cursor/rules/read-project-memories.mdc
+++ b/.cursor/rules/read-project-memories.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---

--- a/.cursor/rules/read-project-memories.mdc
+++ b/.cursor/rules/read-project-memories.mdc
@@ -1,7 +1,7 @@
 ---
-description: Always read all files in project_memories for every interaction
+description: "Always read all files in project_memories for every interaction"
 globs:
-  - project_memories/**/*
+  - "project_memories/**/*"
 alwaysApply: true
 ---
 

--- a/.cursor/rules/read-project-memories.mdc
+++ b/.cursor/rules/read-project-memories.mdc
@@ -1,5 +1,13 @@
 ---
-description:
-globs:
-alwaysApply: false
+description: 
+globs: 
+alwaysApply: true
 ---
+---
+description: Always read all files in project_memories for every interaction
+globs:
+  - project_memories/**/*
+alwaysApply: true
+---
+
+For every interaction, ensure all files in the project_memories directory are read and available as context.

--- a/.cursor/rules/read-project-memories.mdc
+++ b/.cursor/rules/read-project-memories.mdc
@@ -3,11 +3,4 @@ description:
 globs: 
 alwaysApply: true
 ---
----
-description: Always read all files in project_memories for every interaction
-globs:
-  - project_memories/**/*
-alwaysApply: true
----
-
 For every interaction, ensure all files in the project_memories directory are read and available as context.

--- a/.cursor/rules/read-project-memories.mdc
+++ b/.cursor/rules/read-project-memories.mdc
@@ -1,6 +1,8 @@
 ---
-description: 
-globs: 
+description: Always read all files in project_memories for every interaction
+globs:
+  - project_memories/**/*
 alwaysApply: true
 ---
+
 For every interaction, ensure all files in the project_memories directory are read and available as context.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a new configuration rule to ensure files in the project memories directory are always included as context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->