### PR TITLE
Use a dummy graph for requirements gatherer stub

### DIFF
--- a/tests/integration_tests/test_orchestrator.py
+++ b/tests/integration_tests/test_orchestrator.py
@@ -70,7 +70,7 @@ async def test_orchestrator(pytestconfig):
                 {
                     "function": {
                         "name": "Delegate",
-                        "arguments": '{"to": "coder"}',
+                        "arguments": '{"to": "coder_new_pr"}',
                     }
                 }
             ],
@@ -118,7 +118,7 @@ async def test_orchestrator(pytestconfig):
         {"role": "assistant", "content": "The project is done."},
     ]
 
-    graph = OrchestratorGraph()
+    graph = OrchestratorGraph().compiled_graph
     result = await graph.ainvoke(
         State(
             messages=[HumanMessage(content="I want to build a website to sell plants")]

--- a/tests/integration_tests/test_orchestrator.py
+++ b/tests/integration_tests/test_orchestrator.py
@@ -70,7 +70,7 @@ async def test_orchestrator(pytestconfig):
                 {
                     "function": {
                         "name": "Delegate",
-                        "arguments": '{"to": "coder_new_pr"}',
+                        "arguments": '{"to": "coder"}',
                     }
                 }
             ],


### PR DESCRIPTION
orchestrator eval was failing because it was trying to get a `compiled_graph` from the stub. Added a simple graph that returns the stubed function in it's last run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the requirements gathering process with a structured workflow, providing more informative messages and summaries during execution.

- **Tests**
  - Updated integration tests to reflect changes in workflow initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->