### PR TITLE
fix: use AgentConfiguration instead of BaseConfig(deprecated) in Tester 

### DIFF
--- a/src/tester/configuration.py
+++ b/src/tester/configuration.py
@@ -2,12 +2,12 @@
 
 from dataclasses import dataclass
 
-from common.config import BaseConfiguration
+from common.configuration import AgentConfiguration
 from tester import prompts
 
 
 @dataclass(kw_only=True)
-class Configuration(BaseConfiguration):
+class Configuration(AgentConfiguration):
     """Main configuration class for the memory graph system."""
 
     system_prompt: str = prompts.SYSTEM_PROMPT

--- a/src/tester/graph.py
+++ b/src/tester/graph.py
@@ -1,7 +1,6 @@
 """Test Agent Graph Implementation."""
 
 import logging
-from dataclasses import asdict
 from datetime import datetime
 from typing import Any, Coroutine, Optional
 
@@ -17,7 +16,6 @@ from langgraph.prebuilt import ToolNode
 from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 
-from common.configuration import AgentConfiguration
 from common.graph import AgentGraph
 from tester.configuration import Configuration
 from tester.prompts import get_stage_prompt

--- a/src/tester/graph.py
+++ b/src/tester/graph.py
@@ -17,7 +17,7 @@ from langgraph.prebuilt import ToolNode
 from langgraph.store.base import BaseStore
 from langgraph.types import Checkpointer
 
-from common.config import BaseConfiguration
+from common.configuration import AgentConfiguration
 from common.graph import AgentGraph
 from tester.configuration import Configuration
 from tester.prompts import get_stage_prompt
@@ -129,8 +129,7 @@ class TesterAgentGraph(AgentGraph):
     def __init__(
         self,
         *,
-        use_human_ai=False,
-        base_config: Optional[BaseConfiguration] = None,
+        agent_config: Optional[Configuration] = None,
         checkpointer: Optional[Checkpointer] = None,
         store: Optional[BaseStore] = None,
     ):
@@ -138,14 +137,16 @@ class TesterAgentGraph(AgentGraph):
 
         Args:
             use_human_ai: Whether to use human-AI interaction.
-            base_config: Optional BaseConfiguration instance.
+            agent_config: Optional Configuration instance.
             checkpointer: Optional Checkpointer instance.
             store: Optional BaseStore instance.
         """
-        super().__init__(base_config, checkpointer, store)
-        self._name = "Tester"
-        self._config = Configuration(**asdict(self._base_config))
-        self._use_human_ai = use_human_ai
+        super().__init__(
+            name="tester",
+            agent_config=agent_config or Configuration(),
+            checkpointer=checkpointer,
+            store=store,
+        )
 
     def create_builder(self) -> StateGraph:
         """Create a graph builder."""
@@ -156,7 +157,7 @@ class TesterAgentGraph(AgentGraph):
         call_model_name = "call_model"
         tool_node_name = "tools"
 
-        llm = init_chat_model(self._config.model).bind_tools(all_tools)
+        llm = init_chat_model(self._agent_config.model).bind_tools(all_tools)
         tool_node = ToolNode(all_tools, name=tool_node_name)
         call_model = _create_call_model(llm)
         workflow = _create_workflow(call_model_name, tool_node_name)
@@ -179,6 +180,6 @@ class TesterAgentGraph(AgentGraph):
 
 
 # For langsmith
-graph = TesterAgentGraph(base_config=BaseConfiguration()).compiled_graph
+graph = TesterAgentGraph().compiled_graph
 
 __all__ = [TesterAgentGraph.__name__, "graph"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified and unified configuration handling for improved consistency.
  - Updated configuration references and parameter names in the tester agent setup.
  - Streamlined the initialization process for agent configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->