### PR TITLE
fix: Use getpass instead of os to get username

### DIFF
--- a/src/demo/orchestrate.py
+++ b/src/demo/orchestrate.py
@@ -1,8 +1,8 @@
 """Test the orchestrator locally."""
 
 import asyncio
+import getpass
 import json
-import os
 import sys
 import uuid
 from dataclasses import asdict
@@ -129,7 +129,7 @@ if __name__ == "__main__":
         )
 
         run_id = str(uuid.uuid4())
-        user = os.getlogin()
+        user = getpass.getuser()
 
         @traceable(
             run_type="chain",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability when retrieving the current user's login name during orchestration execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->