### PR TITLE
Implement ability to specify different github base branch

### DIFF
--- a/src/common/components/github_mocks.py
+++ b/src/common/components/github_mocks.py
@@ -252,7 +252,9 @@ class MockGithubApi:
         return ""
 
 
-def maybe_mock_github() -> Union[GitHubAPIWrapper, MockGithubApi]:
+def maybe_mock_github(
+    base_branch: str = "main",
+) -> Union[GitHubAPIWrapper, MockGithubApi]:
     """Get either a real GitHub API wrapper or a mock based on environment variables.
 
     Required environment variables for real GitHub API:
@@ -268,6 +270,7 @@ def maybe_mock_github() -> Union[GitHubAPIWrapper, MockGithubApi]:
             github_app_id=os.getenv("GITHUB_APP_ID"),
             github_app_private_key=os.getenv("GITHUB_APP_PRIVATE_KEY"),
             github_repository=os.getenv("GITHUB_REPOSITORY"),
+            github_base_branch=base_branch,
         )
 
     if any(os.getenv(var) for var in required_vars):

--- a/src/orchestrator/configuration.py
+++ b/src/orchestrator/configuration.py
@@ -92,6 +92,7 @@ class Configuration(AgentConfiguration):
     )
     tester_agent: TesterAgentConfig = field(default_factory=TesterAgentConfig)
     reviewer_agent: SubAgentConfig = field(default_factory=SubAgentConfig)
+    github_base_branch: str = "main"
 
 
 __all__ = ["Configuration", "RequirementsAgentConfig", "SubAgentConfig"]

--- a/src/orchestrator/graph.py
+++ b/src/orchestrator/graph.py
@@ -162,7 +162,9 @@ class OrchestratorGraph(AgentGraph):
                 store=self._store,
             )
         )
-        github_tools = get_github_tools(maybe_mock_github())
+        github_tools = get_github_tools(
+            maybe_mock_github(base_branch=self._agent_config.github_base_branch)
+        )
         coder_new_pr_graph = (
             stubs.CoderNewPRStub(
                 agent_config=self._agent_config,

--- a/tests/scenarios/fibonacci.py
+++ b/tests/scenarios/fibonacci.py
@@ -23,6 +23,7 @@ from orchestrator.stubs import MessageWheel
 if __name__ == "__main__":
     orchestrator = OrchestratorGraph(
         agent_config=OrchestratorConfiguration(
+            github_base_branch="fibonacci-base",
             requirements_agent=RequirementsAgentConfig(
                 use_stub=True,
                 stub_messages=MessageWheel(


### PR DESCRIPTION
Used to use a same shared github repo for test scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a GitHub base branch in configuration settings.
- **Tests**
  - Updated scenario tests to use a custom GitHub base branch configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->