### PR TITLE
fix: extract smee URL from environment instead of hardcoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,13 @@ deps: sync
 run: deps
 	uv run --env-file .env -- langgraph dev --allow-blocking --debug-port 2025
 
-smee: smee-mPfw041ExPaQji0
+smee:
+	@SMEE_STRING=$$(grep -E '^SMEE_STRING=' .env | cut -d'=' -f2); \
+	if [ -z "$$SMEE_STRING" ]; then \
+		echo "Error: SMEE_STRING not set in .env file"; \
+		exit 1; \
+	fi; \
+	$(MAKE) smee-$$SMEE_STRING
 
 smee-%:
 	@echo "Direct your webhook payloads to: https://smee.io/$*"


### PR DESCRIPTION
## Summary
- Updated Makefile to read SMEE_STRING from .env file instead of hardcoding it
- Added error handling for missing SMEE_STRING environment variable
- Makes the smee webhook configuration more flexible and maintainable

## Test plan
- [x] Run `make smee` - should read the SMEE_STRING from .env file
- [x] Verify the smee URL matches the value in .env (smee-mPfw041ExPaQji0)
- [x] Test error handling by temporarily removing SMEE_STRING from .env

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the process for running the webhook relay by allowing dynamic configuration through the `.env` file, with clearer error messaging if configuration is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->